### PR TITLE
Ignore button entities

### DIFF
--- a/package_unavailable_entities.yaml
+++ b/package_unavailable_entities.yaml
@@ -23,7 +23,7 @@ template:
               {% set ignore_seconds = 60 %}
               {% set ignore_ts = (now().timestamp() - ignore_seconds)|as_datetime %}
               {{ states
-                |rejectattr('domain','eq','group')
+                |rejectattr('domain','in',['group','button'])
                 |rejectattr('entity_id','in',state_attr('group.ignored_unavailable_entities','entity_id'))
                 |rejectattr('last_changed','ge',ignore_ts)
                 |selectattr('state','in',['unavailable','unknown','none'])|map(attribute='entity_id')|list }}


### PR DESCRIPTION
HASS release 2021.12 introduced the [button entity](https://www.home-assistant.io/blog/2021/12/11/release-202112/#the-button-entity), which acts as a state-less momentary switch.
Since their state is "unknown" by design, they always match the current filter logic.
This PR rejects all entities from the `button` domain.