### PR TITLE
Fix empty list in notification

### DIFF
--- a/package_unavailable_entities.yaml
+++ b/package_unavailable_entities.yaml
@@ -74,6 +74,6 @@ automation:
             data:
               title: 'Unavailable Entities'
               message: >
-                - {{ expand(state_attr('sensor.unavailable_entities','entities'))
+                - {{ expand(state_attr('sensor.unavailable_entities','entitiy_id'))
                       |map(attribute='entity_id')|join('\n- ') }}
               notification_id: unavailable_entities


### PR DESCRIPTION
I think this was missing from the last commit, the notification did appear but with an empty list.

PS: Thanks for this awesome plugin, it is so useful! :blush: