### PR TITLE
Set state_class

### DIFF
--- a/package_unavailable_entities.yaml
+++ b/package_unavailable_entities.yaml
@@ -15,6 +15,7 @@ template:
         state: >
           {% set entities = state_attr(this.entity_id,'entity_id') %}
           {{ entities|count if entities != none else none }}
+        state_class: measurement
         attributes:
           entity_id: >
             {% set ignore_seconds = 60 %}


### PR DESCRIPTION
Set state_class to measurement so that sensor's  More Info shows a graph instead o the default colored bar.