### PR TITLE
Excluding Specific Integrations - real world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ You can exclude entities from a specific integration by using an `in` test for t
 
     |rejectattr('entity_id','in',integration_entities('hassio'))
 
+You have to specifiy a correct integration name that can be different from the one displayed in the list of integrations. For example, you may need to use `garmin_connect` for an integration named _Garmin Connect_.
+
 ### Excluding Specific Devices
 You can exclude entities from a specific integration by using an `in` test for the entity_id and the [device_entities() function](https://www.home-assistant.io/docs/configuration/templating/#devices).
 


### PR DESCRIPTION
I was struggling a bit when trying to set ignored entities for a specific integration because I did not know the integrations precise name that needs to be used in `integration_entities()` function. 

Providing a real world example or describing a way where to get the list of precise integration IDs would help. Especially for integrations that are set up using the GUI and not `configuration.yaml`.

Please, ignore the following diff. Github reports there was a change even when both versions are identical:

```
![Example](https://github.com/jazzyisj/unavailable-entities-sensor/blob/main/images/entities_card_open_example.png)
```