### PR TITLE
Exclude remote domain as remotes do not have a state

### DIFF
--- a/package_unavailable_entities.yaml
+++ b/package_unavailable_entities.yaml
@@ -23,7 +23,7 @@ template:
             {% set ignored = state_attr('group.ignored_unavailable_entities','entity_id') %}
             {% set ignore_ts = (now().timestamp() - ignore_seconds)|as_datetime %}
             {% set entities = states
-                |rejectattr('domain','in',['button','event','group','input_button','input_text','scene'])
+                |rejectattr('domain','in',['button','event','group','input_button','input_text','remote','scene'])
                 |rejectattr('last_changed','ge',ignore_ts) %}
             {% set entities =  entities|rejectattr('entity_id','in',ignored) if ignored != none else entities %}
             {{ entities|map(attribute='entity_id')|reject('has_value')|list|sort }}


### PR DESCRIPTION
Remotes always show as `unknown`.

![image](https://github.com/jazzyisj/unavailable-entities-sensor/assets/50791984/7f901c80-235b-4a0a-ae50-df826b1f3148)

![image](https://github.com/jazzyisj/unavailable-entities-sensor/assets/50791984/842121d5-c2ae-4e5e-88d2-7a23b2163a1b)
