### PR TITLE
Update persistent notification to get unavailable entities info from the group

### DIFF
--- a/examples/detailed_persistent_notification.yaml
+++ b/examples/detailed_persistent_notification.yaml
@@ -23,7 +23,7 @@ automation:
           title: "Unavailable Entities"
           message: >
             {% set ns = namespace(result=[]) %}
-            {% for s in expand(state_attr('sensor.unavailable_entities', 'entity_id')) %}
+            {% for s in expand(state_attr('group.unavailable_entities', 'entity_id')) %}
               {% set ns.result = ns.result + [
                   device_attr(s.entity_id, "name") ~ "|" ~ device_id(s.entity_id) ~ "|- **" ~ s.name ~ "**\n"
                   ~ "  - *entity_id*: " ~ s.entity_id ~ "\n"


### PR DESCRIPTION
As the structure of the sensor has changed, the automation to create the persistent notification needs to be updated to use the group instead of the sensor attribute to get the information of the unavailable entities.